### PR TITLE
[KonaJDK] add Kona JDK 21

### DIFF
--- a/konajdk/README.md
+++ b/konajdk/README.md
@@ -8,12 +8,13 @@ Kona also implements China's cryptographic algorithms, including SM2, SM3 and SM
 
 ## Supported JDK Releases
 
-Tencent Kona currently supports the JDK Long-Term Support (LTS) releases 8, 11 and 17.
+Tencent Kona currently supports the JDK Long-Term Support (LTS) releases 8, 11, 17 and 21.
 For more details, please go through the individual repository for each of these releases:
 
 - Tencent Kona 8: [https://github.com/Tencent/TencentKona-8](https://github.com/Tencent/TencentKona-8)
 - Tencent Kona 11: [https://github.com/Tencent/TencentKona-11](https://github.com/Tencent/TencentKona-11)
 - Tencent Kona 17: [https://github.com/Tencent/TencentKona-17](https://github.com/Tencent/TencentKona-17)
+- Tencent Kona 21: [https://github.com/Tencent/TencentKona-21](https://github.com/Tencent/TencentKona-21)
 
 ## Supported System Platforms
 


### PR DESCRIPTION
Kona JDK 21 just was released, so the main page should introduce it .