### PR TITLE
[KonaJDK] update kona-v1.json for adding 2025Q1 releases

### DIFF
--- a/konajdk/releases/kona-v1.json
+++ b/konajdk/releases/kona-v1.json
@@ -1,6 +1,44 @@
 {
   "8": [
     {
+      "version": "8.0.21",
+      "jdkVersion": "8u442",
+      "latest": true,
+      "baseUrl": "https://github.com/Tencent/TencentKona-8/releases/download/8.0.21-GA/",
+      "files": [
+        {
+          "os": "linux",
+          "arch": "aarch64",
+          "filename": "TencentKona8.0.21.b1_jdk_linux-aarch64_8u442.tar.gz",
+          "checksum": "3b1992873e392bb1be575168c492e3267d74b6f46c5448b01ce3255a294f6b33"
+        },
+        {
+          "os": "linux",
+          "arch": "x86_64",
+          "filename": "TencentKona8.0.21.b1_jdk_linux-x86_64_8u442.tar.gz",
+          "checksum": "2afeb8b43757decfcb0f0e74c345f54e9c24068524564189788b4a5c667bd6de"
+        },
+        {
+          "os": "macos",
+          "arch": "aarch64",
+          "filename": "TencentKona8.0.21.b1_jdk_macosx-aarch64_8u442_notarized.tar.gz",
+          "checksum": "e4baffd11f2d580ed6bc144cd6eefce62da1137a10c74a7a8f1971e0d4be423b"
+        },
+        {
+          "os": "macos",
+          "arch": "x86_64",
+          "filename": "TencentKona8.0.21.b1_jdk_macosx-x86_64_8u442_notarized.tar.gz",
+          "checksum": "a402d8359229fed79554d95b82d52c3dac846d0fb5e079f2bda69bec099e9dcc"
+        },
+        {
+          "os": "windows",
+          "arch": "x86_64",
+          "filename": "TencentKona8.0.21.b1_jdk_windows-x86_64_8u442_signed.zip",
+          "checksum": "614fe8f6d2ee0ab10445613221f53897b9d5c3597faef16001e653e8d32896f0"
+        }
+      ]
+    },
+    {
       "version": "8.0.20",
       "jdkVersion": "8u432",
       "latest": true,
@@ -28,7 +66,7 @@
           "os": "macos",
           "arch": "x86_64",
           "filename": "TencentKona8.0.20.b1_jdk_macosx-x86_64_8u432_notarized.tar.gz",
-          "checksum": ""
+          "checksum": "339646817254dbcb5c17904807bbfdeafaa8e4bac9f2aae25434870cdeaba296"
         },
         {
           "os": "windows",
@@ -78,6 +116,44 @@
     }
   ],
   "11": [
+    {
+      "version": "11.0.26",
+      "jdkVersion": "11.0.26",
+      "latest": true,
+      "baseUrl": "https://github.com/Tencent/TencentKona-11/releases/download/kona11.0.26/",
+      "files": [
+        {
+          "os": "linux",
+          "arch": "aarch64",
+          "filename": "TencentKona-11.0.26.b1-jdk_linux-aarch64.tar.gz",
+          "checksum": "79e37e193e86d1dc3ba8ab50e8b5ebd0004df7e5b392d3f3e637047bd171a6ff"
+        },
+        {
+          "os": "linux",
+          "arch": "x86_64",
+          "filename": "TencentKona-11.0.26.b1-jdk_linux-x86_64.tar.gz",
+          "checksum": "ae2f2353b63da6708bb1d9e309247da78d573bbbf68b0951e3fcbdc454b76a4f"
+        },
+        {
+          "os": "macos",
+          "arch": "aarch64",
+          "filename": "TencentKona-11.0.26.b1_jdk_macosx-aarch64_notarized.tar.gz",
+          "checksum": "dc955cb3dbf4d73079d87bb5160e64e84a4bd56a08d4f9c75bd492446cfc74b3"
+        },
+        {
+          "os": "macos",
+          "arch": "x86_64",
+          "filename": "TencentKona-11.0.26.b1_jdk_macosx-x86_64_notarized.tar.gz",
+          "checksum": "f73a99b41a83118b73812b4ea33e532ae63ad4974953d1a9085d657fb658f63d"
+        },
+        {
+          "os": "windows",
+          "arch": "x86_64",
+          "filename": "TencentKona-11.0.26.b1_jdk_windows-x86_64_signed.zip",
+          "checksum": "abeb6617ae411a72d647a90cfc597dc0596d380c39be9e7b15a8d20994b82861"
+        }
+      ]
+    },
     {
       "version": "11.0.25",
       "jdkVersion": "11.0.25",
@@ -157,6 +233,44 @@
   ],
   "17": [
     {
+      "version": "17.0.14",
+      "jdkVersion": "17.0.14",
+      "latest": true,
+      "baseUrl": "https://github.com/Tencent/TencentKona-17/releases/download/TencentKona-17.0.14/",
+      "files": [
+        {
+          "os": "linux",
+          "arch": "aarch64",
+          "filename": "TencentKona-17.0.14.b1-jdk_linux-aarch64.tar.gz",
+          "checksum": "b9842a94554b7969f4fc317401d56e16398b41ecea49ca00ed47b02406f0edd5"
+        },
+        {
+          "os": "linux",
+          "arch": "x86_64",
+          "filename": "TencentKona-17.0.14.b1-jdk_linux-x86_64.tar.gz",
+          "checksum": "9c010ab4b3f3ff12326acc9fc8311d61a321f8e2e651ab008156fde277268b83"
+        },
+        {
+          "os": "macos",
+          "arch": "aarch64",
+          "filename": "TencentKona-17.0.14.b1_jdk_macosx-aarch64_notarized.tar.gz",
+          "checksum": "767d0af603690285721d27ea2b5b80470850b11aa90c7e0b4d6cd102819970de"
+        },
+        {
+          "os": "macos",
+          "arch": "x86_64",
+          "filename": "TencentKona-17.0.14.b1_jdk_macosx-x86_64_notarized.tar.gz",
+          "checksum": "fc5ab1b32a605901daee6281e766049227c4041302aa4a7b056c1b800b4b4bf1"
+        },
+        {
+          "os": "windows",
+          "arch": "x86_64",
+          "filename": "TencentKona-17.0.14.b1_jdk_windows-x86_64_signed.zip",
+          "checksum": "2156ac70d81839ed88dcd57031c7901b0dc37fd0d9dd54d762bbe5ef854097f4"
+        }
+      ]
+    },
+    {
       "version": "17.0.13",
       "jdkVersion": "17.0.13",
       "latest": true,
@@ -234,6 +348,44 @@
     }
   ],
   "21": [
+    {
+      "version": "21.0.6",
+      "jdkVersion": "21.0.6",
+      "latest": true,
+      "baseUrl": "https://github.com/Tencent/TencentKona-21/releases/download/TencentKona-21.0.6/",
+      "files": [
+        {
+          "os": "linux",
+          "arch": "aarch64",
+          "filename": "TencentKona-21.0.6.b1-jdk_linux-aarch64.tar.gz",
+          "checksum": "7384e0920cdbd73d5a8eabe5714e2df564e3e754eacb2699efad752a7a412250"
+        },
+        {
+          "os": "linux",
+          "arch": "x86_64",
+          "filename": "TencentKona-21.0.6.b1-jdk_linux-x86_64.tar.gz",
+          "checksum": "ffe43ed11347537444681b276b0a798c866445cd1b21a599e5d2692a0e75271a"
+        },
+        {
+          "os": "macos",
+          "arch": "aarch64",
+          "filename": "TencentKona-21.0.6.b1_jdk_macosx-aarch64_notarized.tar.gz",
+          "checksum": "9be0d5e93eb723f09376b2626e158fa8c2dd25e7cada5a35ce73d4f8684fcb7c"
+        },
+        {
+          "os": "macos",
+          "arch": "x86_64",
+          "filename": "TencentKona-21.0.6.b1_jdk_macosx-x86_64_notarized.tar.gz",
+          "checksum": "d698f853936868dc3df8a9fee22afde46ab0bf49b8ad94fbc23ef50d99dc5801"
+        },
+        {
+          "os": "windows",
+          "arch": "x86_64",
+          "filename": "TencentKona-21.0.6.b1_jdk_windows-x86_64_signed.zip",
+          "checksum": "4af308a385fce03dddda279cd663f766c30cb51f76d0bc8cf206d5fa1001670a"
+        }
+      ]
+    },
     {
       "version": "21.0.5",
       "jdkVersion": "21.0.5",


### PR DESCRIPTION
2025Q1 releases: 8.0.21/8u442, 11.0.26, 17.0.12 and 21.0.6.